### PR TITLE
🐛 (rules): fix wrong range dates

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -1,6 +1,6 @@
 rules:
     - name: "Global CPU Usage" # Name of the rule that will be saved
       query: "avg_over_time(cluster:node_cpu:ratio[24h])"  # Query that will generate data
-      start: "yesterday"
-      end: "today"
-      step: "1d"
+      start: "yesterday midnight"
+      end: "today midnight"
+      step: "24h"


### PR DESCRIPTION
Updated the `start` and `end` fields of our rule.

The previous range ("yesterday" and "today") was translated as follows:

    The start was from yesterday at the script's starting time until today at the script's starting time.

Example:

    today    :    04/10/2025 10:30
    yesterday:    03/10/2025 10:30

This was causing multiple, redundant values for each script call inside InfluxDB.
With this change, the ranges are updated to:

```diff
- start: "yesterday"
- end: "today"
+ start: "yesterday midnight"
+ end: "today midnight"
```

This ensures that every time the script runs, we get the full, accurate statistics from the past day. 📈